### PR TITLE
rename merged.idf to avoid confusion with curated .idf file

### DIFF
--- a/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
+++ b/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
@@ -849,7 +849,7 @@ sub write_magetab
 {
 	my ($self) = @_;
 
-	my $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".idf.txt" );
+	my $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".merged.idf.txt" );
 
 	open( my $idf_fh, ">:encoding(utf-8)", $idf )
 	  or $logger->error("Could not open IDF $idf for writing - $!");

--- a/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
+++ b/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
@@ -847,18 +847,18 @@ sub _make_id_ref_map_for
 
 sub write_magetab
 {
-    my ($self, $prefix_idf) = @_;
+	my ($self, $prefix_idf) = @_;
 
-    my $idf;
-    
-    if ($prefix_idf) {
-        $logger->warn("Writing IDF with prefix - $prefix_idf");
-        $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".$prefix_idf" .".idf.txt" );
-    }
-    else {
-        $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".idf.txt" );
-    }
+	my $idf;
 
+	if ($prefix_idf) {
+		$logger->warn("Writing IDF with prefix - $prefix_idf");
+		$idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".$prefix_idf" . ".idf.txt" );
+	}
+	else {
+		$idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".idf.txt" );
+	}
+	
 	open( my $idf_fh, ">:encoding(utf-8)", $idf )
 	  or $logger->error("Could not open IDF $idf for writing - $!");
 

--- a/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
+++ b/perl_modules/EBI/FGPT/Converter/GEO/SOFTtoMAGETAB.pm
@@ -847,9 +847,17 @@ sub _make_id_ref_map_for
 
 sub write_magetab
 {
-	my ($self) = @_;
+    my ($self, $prefix_idf) = @_;
 
-	my $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".merged.idf.txt" );
+    my $idf;
+    
+    if ($prefix_idf) {
+        $logger->warn("Writing IDF with prefix - $prefix_idf");
+        $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".$prefix_idf" .".idf.txt" );
+    }
+    else {
+        $idf = File::Spec->catfile( $self->get_target_dir, $self->get_acc . ".idf.txt" );
+    }
 
 	open( my $idf_fh, ">:encoding(utf-8)", $idf )
 	  or $logger->error("Could not open IDF $idf for writing - $!");


### PR DESCRIPTION
In this PR,
- The renaming of consolidate uncurated merged MAGETAB i.e. IDF and SDRF is renamed as 'merged.idf.txt' to make it explicit and avoid confusion with curated idf.file.