### PR TITLE
added proteomics_differential to be eligible for Atlas

### DIFF
--- a/supporting_files/AtlasSiteConfig.yml
+++ b/supporting_files/AtlasSiteConfig.yml
@@ -32,6 +32,7 @@ allowed_xml_experiment_types:
     - rnaseq_mrna_differential
     - rnaseq_mrna_baseline
     - proteomics_baseline
+    - proteomics_differential
 
 # Allowed data usage agreements for factors XML configuration file.
 allowed_data_usage_agreements:


### PR DESCRIPTION
In this PR,
- The config is updated to make atlas eligible for `proteomics_differential` analysis in AtlasSiteConfig.yml. 
Since this file also exists in the file system that gets overwritten during bamboo deployment I've updated these changes into that file as well. 
- Have tested this change locally and by Nancy to generate E-PROT-39-configuration.xml  under ```/ebi/microarray/home/suhaib/proteomics_differential```