### PR TITLE
Optional ADFs-checked files

### DIFF
--- a/perl_modules/EBI/FGPT/CheckSet/AEAtlas.pm
+++ b/perl_modules/EBI/FGPT/CheckSet/AEAtlas.pm
@@ -1440,8 +1440,11 @@ sub check_microarray_adf_support {
 
 
 
-
-    my $use_tracking_files = $CONFIG->get_USE_CHECKED_LIST_FILE;
+    # A "true" flag in the config can be used to skip the writing to the "checked files"
+    my $skip_tracking_files = $CONFIG->get_SKIP_CHECKED_LIST_FILES eq "true";
+    if ($skip_tracking_files) {
+        $self->debug("Skipping writing to ADF checked files");
+    }
     my (%absent_adf_acc_count, @checked_expt_list);
 
 
@@ -1504,7 +1507,7 @@ sub check_microarray_adf_support {
         }
     }
 
-    if ($use_tracking_files) {
+    unless ($skip_tracking_files) {
 
         #######################################
         #######################################

--- a/supporting_files/ArrayExpressSiteConfig.yml
+++ b/supporting_files/ArrayExpressSiteConfig.yml
@@ -78,7 +78,7 @@ VALIDATION_SCRIPT:
 # Location of ADF and Experiments checked in Atlas.pm
 ADF_CHECKED_LIST:        /nfs/production3/ma/home/atlas3-production/sw/configs/adfs_not_in_atlas.txt
 ATLAS_EXPT_CHECKED_LIST: /nfs/production3/ma/home/atlas3-production/sw/configs/expts_checked_for_atlas.txt
-USE_CHECKED_LIST_FILE:  false
+SKIP_CHECKED_LIST_FILES:  true
 
 PRIVATE_ADF_USERNAME:    xxxx
 PRIVATE_ADF_PASSWORD:    xxxxx

--- a/supporting_files/ArrayExpressSiteConfig.yml
+++ b/supporting_files/ArrayExpressSiteConfig.yml
@@ -78,6 +78,7 @@ VALIDATION_SCRIPT:
 # Location of ADF and Experiments checked in Atlas.pm
 ADF_CHECKED_LIST:        /nfs/production3/ma/home/atlas3-production/sw/configs/adfs_not_in_atlas.txt
 ATLAS_EXPT_CHECKED_LIST: /nfs/production3/ma/home/atlas3-production/sw/configs/expts_checked_for_atlas.txt
+USE_CHECKED_LIST_FILE:  false
 
 PRIVATE_ADF_USERNAME:    xxxx
 PRIVATE_ADF_PASSWORD:    xxxxx


### PR DESCRIPTION
This changes makes the requirement for the server-resident files "adfs_not_in_atlas.txt" and "expts_checked_for_atlas.txt"
optional. These files are required in the AEAtlas.pm module for doing Atlas checks on microarray experiments (counting occurrences of array designs that have been found in experiments but that are not in Atlas; the expts_checked_for_atlas.txt is used to not count the an ADF from the same experiment more than once).

I've introduced a new field in the configuration file "ArrayExpressSiteConfig.yml" called "USE_CHECKED_LIST_FILE" that can be set to true/false. If false, then the files are not required and the validation runs without errors for microarray experiments. I think this is the best approach for the end users, as this allows us to set the config on the server with the value to "true", while curators running the script locally can use the "false" setting (from the module package) and don't need to add an extra flag every time. 

My IDE smuggled in a few white space code styling changes, please ignore. 