### PR TITLE
Remove ProxyAny

### DIFF
--- a/perl_modules/EBI/FGPT/Converter/GEO/GeoExperiment.pm
+++ b/perl_modules/EBI/FGPT/Converter/GEO/GeoExperiment.pm
@@ -4,7 +4,6 @@ package EBI::FGPT::Converter::GEO::GeoExperiment;
 
 use LWP::Simple qw($ua get);
 use XML::XPath;
-use LWP::UserAgent::ProxyAny;
 use HTTP::Status;
 use File::Spec;
 use File::Temp qw(tempfile);


### PR DESCRIPTION
This module isn't available in bioconda and currently breaks running the GEO importer in an all-conda resolved environment. This PR removes requirement for this proxy setting. 
Thanks @YalanBi for confirming that this isn't vital. Tested with normal GEO experiment import and it works. 