### PR TITLE
Handle license file backwards compatibly

### DIFF
--- a/perl_modules/Atlas/AtlasConfig/FactorsConfig.pm
+++ b/perl_modules/Atlas/AtlasConfig/FactorsConfig.pm
@@ -248,16 +248,17 @@ sub _read_gxa_license {
         );
     }
 
-    my $atlasProdDir = $ENV{ "ATLAS_PROD" };
-
-    unless( $atlasProdDir ) {
-        $logger->logdie( 
-            "ATLAS_PROD environment variable is not set. Cannot locate GXA license file."
-        );
+    unless ( -r $gxaLicenseFile ) {
+        # only read in the previous way merging $atlasProdDir if $gxaLicenseFile doesn't get a complete file
+        my $atlasProdDir = $ENV{ "ATLAS_PROD" };
+        unless( $atlasProdDir ) {
+            $logger->logdie( 
+                "ATLAS_PROD environment variable is not set. Cannot locate GXA license file."
+            );
+        }
+        $gxaLicenseFile = File::Spec->catfile( $atlasProdDir, $gxaLicenseFile );
     }
-
-    $gxaLicenseFile = File::Spec->catfile( $atlasProdDir, $gxaLicenseFile );
-
+    
     unless( -r $gxaLicenseFile ) {
         $logger->logdie(
             "Cannot read ",


### PR DESCRIPTION
After a revamp of the config handling, the handling of this license fail was left in a failed state, in which it is  merging the atlasProdPath forcefully with whatever is present in the AtlasSiteConfig file for the license file. This PR tries to accommodate both cases for backwards compatibility. Note that this has been working fine in noah because the curators have been using there the outdated version that remained in atlas-prod.