### PR TITLE
Add `proteomics_baseline_dia` to allowed experiment types in XML configuration file

### DIFF
--- a/supporting_files/AtlasSiteConfig.yml.default
+++ b/supporting_files/AtlasSiteConfig.yml.default
@@ -32,6 +32,7 @@ allowed_xml_experiment_types:
     - rnaseq_mrna_differential
     - rnaseq_mrna_baseline
     - proteomics_baseline
+    - proteomics_baseline_dia
     - proteomics_differential
 
 # Allowed data usage agreements for factors XML configuration file.


### PR DESCRIPTION
This adds a type of experiment currently present in Atlas, but not listed in `AtlasSiteConfig.yml`